### PR TITLE
Simplified the code used to detect the editor

### DIFF
--- a/webyep-system/program/editors/rich-text.php
+++ b/webyep-system/program/editors/rich-text.php
@@ -15,58 +15,25 @@
       include_once($oEditorsFolder->sPath);
    }
 
-   $oP = od_clone($goApp->oProgramPath);
-   $oP->addComponent("opt");
-   $oP->addComponent("redactor");
-   
-   
-   if ($oP->bExists() && basename($oP->sPath) == 'tinymce') {
-      $oEditorsFolder->addComponent("rich-text-tinymce.php");
-	   include_once($oEditorsFolder->sPath);
-   }
-   else {
-      unset($oP);
+   // Supported editors.
+   $editors = array('ckeditor', 'fckeditor', 'redactor', 'rte', 'tinymce');
+   $activeEditor = NULL;
+   foreach ($editors as $editor) {
       $oP = od_clone($goApp->oProgramPath);
       $oP->addComponent("opt");
-      $oP->addComponent("redactor");
+      $oP->addComponent($editor);
       if ($oP->bExists()) {
-         $oEditorsFolder->addComponent("rich-text-redactor.php");       
+         $activeEditor = $editor;
+         $oEditorsFolder->addComponent("rich-text-{$editor}.php");
          include_once($oEditorsFolder->sPath);
+         break;
       }
-	  else {
-		  unset($oP);
-		  $oP = od_clone($goApp->oProgramPath);
-		  $oP->addComponent("opt");
-		  $oP->addComponent("rte");
-		  if ($oP->bExists()) {
-			 $oEditorsFolder->addComponent("rich-text-rte.php");
-			 include_once($oEditorsFolder->sPath);
-		  }
-		  else {
-			  unset($oP);
-			  $oP = od_clone($goApp->oProgramPath);
-			  $oP->addComponent("opt");
-			  $oP->addComponent("fckeditor");
-			  if ($oP->bExists()) {
-				 $oEditorsFolder->addComponent("rich-text-fckeditor.php");
-				 include_once($oEditorsFolder->sPath);
-			  }
-			 else {
-					unset($oP);
-					$oP = od_clone($goApp->oProgramPath);
-					$oP->addComponent("opt");
-					$oP->addComponent("ckeditor");
-					if ($oP->bExists()) {
-						$oEditorsFolder->addComponent("rich-text-ckeditor.php");
-						include_once($oEditorsFolder->sPath);
-					}
-					else {
-						$oEditorsFolder->addComponent("rich-text-plain.php");
-						include_once($oEditorsFolder->sPath);
-					}
-			 }
-		  }
-	  }
+   }
+
+   // If no active editor, fall back to the plain text editor.
+   if (!$activeEditor) {
+      $oEditorsFolder->addComponent("rich-text-plain.php");
+      include_once($oEditorsFolder->sPath);
    }
 
 ?>


### PR DESCRIPTION
I was noticing that TinyMCE was not being detected. This is because line 20 of `webyep-system/program/editors/rich-text.php` has "redactor", but it should be "tinymce".

In the process of fixing that bug, I found that the editor detection code was repeating itself, so I simplified it in this patch.