### PR TITLE
Fixing errors in the php error log

### DIFF
--- a/webyep-system/program/elements/WYLoopElement.php
+++ b/webyep-system/program/elements/WYLoopElement.php
@@ -2,7 +2,7 @@
 // WebYep
 // (C) Objective Development Software GmbH
 // http://www.obdev.at
-session_start(); 
+//session_start(); // Disabled because this isn't currently in use.
 
 include_once(@webyep_sConfigValue("webyep_sIncludePath") . "/lib/WYElement.php");
 include_once(@webyep_sConfigValue("webyep_sIncludePath") . "/lib/WYLink.php");
@@ -43,7 +43,7 @@ class WYLoopElement extends WYElement
 	{
           global $webyep_oCurrentLoop;
          //
-         $a=$webyep_oCurrentLoop->iLoopID;
+         //$a=$webyep_oCurrentLoop->iLoopID;
          //print_r($a);
          //echo 'hello'; 
           //$webyep_oCurrentLoop->iLoopID=$_SESSION["loopid"];

--- a/webyep-system/program/elements/WYRichTextElement.php
+++ b/webyep-system/program/elements/WYRichTextElement.php
@@ -86,10 +86,10 @@ class WYRichTextElement extends WYElement
    function sEditButtonHTML($sButtonImage = "edit-button.gif", $sToolTip = "", $oCustomEditURL = false)
    {
       $this->dEditorQuery = array();
-      if(isset($_SESSION['iLoopID'])){
-      $this->dEditorQuery[WY_QK_LOOP_ID]=$_SESSION['iLoopID'];
+      if(isset($_SESSION['loopid'])){
+      $this->dEditorQuery[WY_QK_LOOP_ID]=$_SESSION['loopid'];
       }
-      if ($this->oCSSURL) +$this->dEditorQuery[WY_QK_RICH_TEXT_CSS] = $this->oCSSURL->sURL();
+      if ($this->oCSSURL) $this->dEditorQuery[WY_QK_RICH_TEXT_CSS] = $this->oCSSURL->sURL();
       else $this->dEditorQuery[WY_QK_RICH_TEXT_CSS] = "";
 	   return parent::sEditButtonHTML($sButtonImage, $sToolTip);
    }

--- a/webyep-system/program/lib/WYPopupWindowLink.php
+++ b/webyep-system/program/lib/WYPopupWindowLink.php
@@ -57,7 +57,7 @@ class WYPopupWindowLink extends WYHTMLTag
 		$this->dAttributes["href"] = $oURL->sEURL();
 
 		//if(!empty($webyep_oCurrentLoop)){ echo "yes";
-		$loopid= $_SESSION["loopid"];
+		$loopid = isset($_SESSION["loopid"]) ? $_SESSION["loopid"] : 0;
 		//}else { $loopid=0; print_r($webyep_oCurrentLoop);}
 
 		$url=$oURL->sURL();$WEBYEP_LOOP_ID="0";


### PR DESCRIPTION
I encountered a handful of errors in the php error log during basic page navigation and editing. These few changes help to remove those errors.

Notes on specific changes:

**WYLoopElement.php**
- I removed `session_start()` on line 5 since that file didn't appear to be using $_SESSION, and it was causing conflicts with `session_start()` that was declared in `WYGalleryElement.php`.
- I commented out line 46 because `$webyep_oCurrentLoop->iLoopID` was not declared, and that line just looked like debugging code.

**WYRichTextElement.php**
- On line 89/90, there appeared to be no other places in the code that were using `$_SESSION['iLoopID']`, so I changed it to the more commonly used `$_SESSION["loopid"]`.
- On line 92, I removed a plus sign which was most likely a typo -- it was causing numeric value errors.

**WYPopupWindowLink.php**
 - On line 60, `$_SESSION['loopid']` was showing errors about `Undefined index: loopid`.